### PR TITLE
fixed Exception ”Cannot use object of type stdClass as array” when pr…

### DIFF
--- a/app/code/community/Bubble/Api/Helper/Catalog/Product.php
+++ b/app/code/community/Bubble/Api/Helper/Catalog/Product.php
@@ -115,6 +115,18 @@ class Bubble_Api_Helper_Catalog_Product extends Mage_Core_Helper_Abstract
         if (!$mainProduct->isConfigurable() || empty($simpleProductIds)) {
             return $this;
         }
+        
+        /* block added to prevent exception "Cannot use object of type stdClass as array" */
+        if(is_object($priceChanges))
+        {
+            $tmp = array();
+            $attributeCode = $priceChanges->key;
+            foreach($priceChanges->value AS $optionText)
+            {
+                $tmp[$attributeCode][$optionText->key] = $optionText->value;
+            }
+            $priceChanges = $tmp;
+        }
 
         $mainProduct->setConfigurableProductsData(array_flip($simpleProductIds));
         $productType = $mainProduct->getTypeInstance(true);


### PR DESCRIPTION
…ice_changes

Function needs an array but receive an object.

Here's how I defined my configurable product :

```
        $associatedSkus = array();
        $price_changes = array();
        foreach($product->produitsSimples AS $etat => $produitSimple) {
            $price_changes[] = array('key' => $etat, 'value' => (string) floatval($produitSimple->prix));
            $associatedSkus[] = $produitSimple->codeEAN;
        }
```

[...]
               'price_changes' => array(
                    array(
                        'key' => 'etat',
                        'value' => $price_changes
                    )
                ),
